### PR TITLE
fix: fixed accuracy calc bug in absolute difference task

### DIFF
--- a/llmthinkbench/tasks/absolute_difference_task.py
+++ b/llmthinkbench/tasks/absolute_difference_task.py
@@ -38,14 +38,8 @@ class AbsoluteDifferenceTask(BaseTask):
         instruction_followed, answer = parse_absolute_difference_answer(response)
         accuracy = 0
         
-        if instruction_followed and answer is not None:
-            try:
-                # Convert answer to int if it's not already
-                if isinstance(answer, str):
-                    answer = int(float(answer))
-                accuracy = 1 if answer == ground_truth else 0
-            except (ValueError, TypeError):
-                accuracy = 0
+        if (ground_truth == answer):
+            accuracy = 1
         
         return {
             "input_numbers": data_point,


### PR DESCRIPTION
For absolute difference tasks

Though the ground truth and parsed response are the same, the model reports accuracy as 0, which is undesirable. And there are multiple instances of this occurrence. 4 out of the 7 accuracy: 0 are falsely reported. 

This PR fixes this issue. I have tested it again on Qwen2.5-1.5B for the absolute difference task and it is working fine. Now only cases where the parsed_response and the ground_truth are difference are reported as accuracy:0 as expected

